### PR TITLE
Implement S3 bucket creation with sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
-# Ministry of Justice Template Repository
+# modernisation-platform-terraform-s3-bucket
 
-Use this template to [create a repository] with the default initial files for a Ministry of Justice Github repository, including:
+A Terraform module to standardise S3 buckets with sensible defaults.
 
-* The correct LICENSE
-* Github actions
-* .gitignore file
+## Usage
 
-Once you have created your repository, please:
+```
+module "s3-bucket" {
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  bucket_prefix = "s3-bucket"
+  tags          = local.tags
+}
+```
 
-* Edit the copy of this README.md file to document your project
-* Grant permissions to the appropriate MoJ teams
-* Setup branch protection
+## Inputs
+| Name                   | Description                                                                           | Type    | Default   | Required |
+|------------------------|---------------------------------------------------------------------------------------|---------|-----------|----------|
+| acl                    | Canned ACL to use on the bucket                                                       | string  | `private` | no       |
+| bucket_policy          | JSON for the bucket policy, see note below                                            | string  | ""        | no       |
+| bucket_prefix          | Bucket prefix, which will include a randomised suffix to ensure globally unique names | string  |           | yes      |
+| custom_kms_key         | KMS key ARN to use                                                                    | string  | ""        | no       |
+| enable_lifecycle_rules | Whether or not to enable standardised lifecycle rules                                 | boolean | false     | no       |
+| log_bucket             | Bucket for server access logging, if applicable                                       | string  | ""        | no       |
+| log_prefix             | Prefix to use for server access logging, if applicable                                | string  | ""        | no       |
+| tags                   | Tags to apply to resources, where applicable                                          | map     |           | yes      |
 
-[create a repository]: https://github.com/ministryofjustice/template-repository/generate
+## Bucket policies
+Regardless of whether a custom bucket policy is set as part of this module, we will always include policy `statement` to require the use of SecureTransport (SSL) for every action on and every resource within the bucket.
+
+## Outputs
+See the [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#attributes-reference) attributes reference. This module outputs the resource map, i.e. `aws_s3_bucket`, so you can access each attribute from Terraform directly under the `bucket` output, e.g. `module.s3-bucket.bucket.id` for the bucket ID.
+
+## Looking for issues?
+If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,87 @@
+resource "aws_s3_bucket" "default" {
+  bucket_prefix = var.bucket_prefix
+  acl           = var.acl
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  dynamic lifecycle_rule {
+    for_each = var.enable_lifecycle_rules ? [var.enable_lifecycle_rules] : []
+
+    content {
+      enabled = var.enable_lifecycle_rules
+
+      noncurrent_version_transition {
+        days          = 30
+        storage_class = "GLACIER"
+      }
+
+      transition {
+        days          = 30
+        storage_class = "GLACIER"
+      }
+    }
+  }
+
+  dynamic logging {
+    for_each = (length(var.log_bucket) > 0) ? [var.log_bucket] : []
+
+    content {
+      target_bucket = var.log_bucket
+      target_prefix = var.log_prefix
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = (length(var.custom_kms_key) > 0) ? var.custom_kms_key : ""
+      }
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket                  = aws_s3_bucket.default.bucket
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = aws_s3_bucket.default.id
+  policy = data.aws_iam_policy_document.default.json
+}
+
+data "aws_iam_policy_document" "default" {
+  override_json = var.bucket_policy
+
+  statement {
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.default.arn,
+      "${aws_s3_bucket.default.arn}/*"
+    ]
+
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,3 @@
+output "bucket" {
+  value = aws_s3_bucket.default
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,45 @@
+variable "acl" {
+  type        = string
+  description = "Canned ACL to use on the bucket"
+  default     = "private"
+}
+
+variable "bucket_policy" {
+  type        = string
+  description = "JSON for the bucket policy"
+  default     = ""
+}
+
+variable "bucket_prefix" {
+  type        = string
+  description = "Bucket prefix, which will include a randomised suffix to ensure globally unique names"
+}
+
+variable "custom_kms_key" {
+  type        = string
+  description = "KMS key ARN to use"
+  default     = ""
+}
+
+variable "enable_lifecycle_rules" {
+  type        = bool
+  description = "Whether or not to enable standardised lifecycle rules"
+  default     = false
+}
+
+variable "log_bucket" {
+  type        = string
+  description = "Bucket for server access logging, if applicable"
+  default     = ""
+}
+
+variable "log_prefix" {
+  type        = string
+  description = "Prefix to use for server access logging, if applicable"
+  default     = ""
+}
+
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This PR is the initial implementation of a standardised configuration for S3 buckets with sensible defaults.

This module offers:
- canned lifecycle rules
- server-side encryption always enabled
- versioning always enabled
- public access block always enabled
- `SecureTransport` (SSL) always required for the S3 bucket, even with a custom policy