### PR TITLE
Remove home_region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A Terraform module to standardise S3 buckets with sensible defaults.
 module "s3-bucket" {
   source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
   bucket_prefix        = "s3-bucket"
-  home_region          = "eu-west-2"
   replication_region   = "eu-west-1"
   replication_role_arn = module.s3-bucket-replication-role.role.arn
   tags                 = local.tags
@@ -23,7 +22,6 @@ module "s3-bucket" {
 | bucket_prefix          | Bucket prefix, which will include a randomised suffix to ensure globally unique names | string  |           | yes      |
 | custom_kms_key         | KMS key ARN to use                                                                    | string  | ""        | no       |
 | enable_lifecycle_rules | Whether or not to enable standardised lifecycle rules                                 | boolean | false     | no       |
-| home_region            | Region to create the main S3 bucket in                                                | string  |           | yes      |
 | log_bucket             | Bucket for server access logging, if applicable                                       | string  | ""        | no       |
 | log_prefix             | Prefix to use for server access logging, if applicable                                | string  | ""        | no       |
 | replication_region     | Region to replicate the main S3 bucket in                                             | string  |           | yes      |

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,4 @@
-# Configure two providers, one for the home region,
-# and one for the replication region
-provider "aws" {
-  region = var.home_region
-}
-
+# Configure a provider in the region of the bucket replication
 provider "aws" {
   alias  = "bucket-replication"
   region = var.replication_region

--- a/variables.tf
+++ b/variables.tf
@@ -27,11 +27,6 @@ variable "enable_lifecycle_rules" {
   default     = false
 }
 
-variable "home_region" {
-  type        = string
-  description = "Region to create the S3 bucket in"
-}
-
 variable "log_bucket" {
   type        = string
   description = "Bucket for server access logging, if applicable"
@@ -46,7 +41,7 @@ variable "log_prefix" {
 
 variable "replication_region" {
   type        = string
-  description = "Region to replicate the S3 bucket to. It can be the same as home_region"
+  description = "Region to replicate the S3 bucket to"
 }
 
 variable "replication_role_arn" {


### PR DESCRIPTION
This removes the `home_region` variable, as we can infer that from the caller identity. It allows the module to use the default Terraform provider (if a custom one isn't set), which also resolves an issue with migrating buckets to use this module as Terraform wanted to destroy and recreate the buckets as they had a new provider.