### PR TITLE
Remove region setting within the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,24 @@ A Terraform module to standardise S3 buckets with sensible defaults.
 
 ## Usage
 
+This module inherits the default provider, though you'll need to pass through your replication region. For example, to create the original bucket in eu-west-2, and to replicate it in eu-west-1:
+
 ```
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "bucket-replication"
+  region = "eu-west-1"
+}
+
 module "s3-bucket" {
   source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  providers = {
+    aws.bucket-replication = aws.eu-west-2
+  }
   bucket_prefix        = "s3-bucket"
-  home_region          = "eu-west-2"
-  replication_region   = "eu-west-1"
   replication_role_arn = module.s3-bucket-replication-role.role.arn
   tags                 = local.tags
 }
@@ -23,10 +35,8 @@ module "s3-bucket" {
 | bucket_prefix          | Bucket prefix, which will include a randomised suffix to ensure globally unique names | string  |           | yes      |
 | custom_kms_key         | KMS key ARN to use                                                                    | string  | ""        | no       |
 | enable_lifecycle_rules | Whether or not to enable standardised lifecycle rules                                 | boolean | false     | no       |
-| home_region            | Region to create the main S3 bucket in                                                | string  |           | yes      |
 | log_bucket             | Bucket for server access logging, if applicable                                       | string  | ""        | no       |
 | log_prefix             | Prefix to use for server access logging, if applicable                                | string  | ""        | no       |
-| replication_region     | Region to replicate the main S3 bucket in                                             | string  |           | yes      |
 | replication_role_arn   | IAM Role ARN for replication. See below for more information                          | string  |           | yes      |
 | tags                   | Tags to apply to resources, where applicable                                          | map     |           | yes      |
 

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,7 @@
-# Configure two providers, one for the home region,
-# and one for the replication region
+# The default calling provider is inherited here, so we only need to create
+# a new one for the replicated region.
 provider "aws" {
-  region = var.home_region
-}
-
-provider "aws" {
-  alias  = "bucket-replication"
-  region = var.replication_region
+  alias = "bucket-replication"
 }
 
 # Main S3 bucket, that is replicated from (rather than to)

--- a/variables.tf
+++ b/variables.tf
@@ -27,11 +27,6 @@ variable "enable_lifecycle_rules" {
   default     = false
 }
 
-variable "home_region" {
-  type        = string
-  description = "Region to create the S3 bucket in"
-}
-
 variable "log_bucket" {
   type        = string
   description = "Bucket for server access logging, if applicable"
@@ -42,11 +37,6 @@ variable "log_prefix" {
   type        = string
   description = "Prefix to use for server access logging, if applicable"
   default     = ""
-}
-
-variable "replication_region" {
-  type        = string
-  description = "Region to replicate the S3 bucket to. It can be the same as home_region"
 }
 
 variable "replication_role_arn" {


### PR DESCRIPTION
This PR removes region setting within the module and utilises inherited `provider` declarations instead. It means you can use `assume_role` in a provider declaration outside of the module, and it will continue to assume that role.