### PR TITLE
Allow setting of bucket_name for a non-randomised bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ module "s3-bucket" {
 ```
 
 ## Inputs
+
 | Name                   | Description                                                                           | Type    | Default   | Required |
 |------------------------|---------------------------------------------------------------------------------------|---------|-----------|----------|
 | acl                    | Canned ACL to use on the bucket                                                       | string  | `private` | no       |
+| bucket_name            | Can be used to set a non-random bucket name, required if not using bucket_prefix      | string  | `null`    | no       |
 | bucket_policy          | JSON for the bucket policy, see note below                                            | string  | ""        | no       |
-| bucket_prefix          | Bucket prefix, which will include a randomised suffix to ensure globally unique names | string  |           | yes      |
+| bucket_prefix          | Bucket prefix, which will include a randomised suffix to ensure globally unique names | string  | `null`    | yes      |
 | custom_kms_key         | KMS key ARN to use                                                                    | string  | ""        | no       |
 | enable_lifecycle_rules | Whether or not to enable standardised lifecycle rules                                 | boolean | false     | no       |
 | log_bucket             | Bucket for server access logging, if applicable                                       | string  | ""        | no       |

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ provider "aws" {
 
 # Main S3 bucket, that is replicated from (rather than to)
 resource "aws_s3_bucket" "default" {
+  bucket        = var.bucket_name
   bucket_prefix = var.bucket_prefix
   acl           = var.acl
 
@@ -115,7 +116,8 @@ data "aws_iam_policy_document" "default" {
 # Replication S3 bucket, to replicate to (rather than from)
 resource "aws_s3_bucket" "replication" {
   provider      = aws.bucket-replication
-  bucket_prefix = "${var.bucket_prefix}-replication"
+  bucket        = (var.bucket_name != null) ? "${var.bucket_name}-replication" : null
+  bucket_prefix = (var.bucket_prefix != null) ? "${var.bucket_prefix}-replication" : null
   acl           = "private"
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,13 @@ variable "bucket_policy" {
 variable "bucket_prefix" {
   type        = string
   description = "Bucket prefix, which will include a randomised suffix to ensure globally unique names"
+  default     = null
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Please use bucket_prefix instead of bucket_name to ensure a globally unique name."
+  default     = null
 }
 
 variable "custom_kms_key" {


### PR DESCRIPTION
Introduces the `bucket_name` variable to allow you to set or migrate static bucket IDs into the module.