### PR TITLE
Fix conflict with a bucket policy and Public Access Block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,9 @@ resource "aws_s3_bucket_public_access_block" "default" {
 resource "aws_s3_bucket_policy" "default" {
   bucket = aws_s3_bucket.default.id
   policy = data.aws_iam_policy_document.default.json
+
+  # Create the Public Access Block before the policy is added
+  depends_on = [aws_s3_bucket_public_access_block.default]
 }
 
 data "aws_iam_policy_document" "default" {
@@ -157,6 +160,9 @@ resource "aws_s3_bucket_policy" "replication" {
   provider = aws.bucket-replication
   bucket   = aws_s3_bucket.replication.id
   policy   = data.aws_iam_policy_document.replication.json
+
+   # Create the Public Access Block before the policy is added
+  depends_on = [aws_s3_bucket_public_access_block.replication]
 }
 
 data "aws_iam_policy_document" "replication" {

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_s3_bucket_policy" "replication" {
   bucket   = aws_s3_bucket.replication.id
   policy   = data.aws_iam_policy_document.replication.json
 
-   # Create the Public Access Block before the policy is added
+  # Create the Public Access Block before the policy is added
   depends_on = [aws_s3_bucket_public_access_block.replication]
 }
 


### PR DESCRIPTION
If you try to create a bucket policy and a public access block at the same time, AWS will throw an error:
`A conflicting conditional operation is currently in progress against this resource`.

To resolve that, this PR explicitly chains a dependency on the Public Access Block needing to be in place before the bucket policy is added.