### PR TITLE
Fix versions, variables and add outputs.tf file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "default" {
     prevent_destroy = true
   }
 
-  dynamic lifecycle_rule {
+  dynamic "lifecycle_rule" {
     for_each = var.enable_lifecycle_rules ? [var.enable_lifecycle_rules] : []
 
     content {
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "default" {
     }
   }
 
-  dynamic logging {
+  dynamic "logging" {
     for_each = (length(var.log_bucket) > 0) ? [var.log_bucket] : []
 
     content {

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,0 @@
-output "bucket" {
-  value = aws_s3_bucket.default
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket" {
+  value       = aws_s3_bucket.default
+  description = "Direct aws_s3_bucket resource with all attributes"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "acl" {
 variable "bucket_policy" {
   type        = string
   description = "JSON for the bucket policy"
-  default     = ""
+  default     = "{}"
 }
 
 variable "bucket_prefix" {
@@ -52,6 +52,6 @@ variable "replication_role_arn" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "Tags to apply to resources, where applicable"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` provider version.

It also renames `output.tf` to `outputs.tf` file to match the best practices for [module code structure](https://www.terraform-best-practices.com/code-structure#getting-started-with-structuring-of-terraform-configurations), adds a missing output description, and tightens allowed variable types.

Once this is merged we can release v1.0.0 of this, so we can pin it as part of ministryofjustice/modernisation-platform#72.