### PR TITLE
Fixed README pointing to a wrong alias that doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "s3-bucket" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v3.0.0"
 
   providers = {
-    aws.bucket-replication = aws.eu-west-2
+    aws.bucket-replication = aws.bucket-replication
   }
   bucket_prefix        = "s3-bucket"
   replication_role_arn = module.s3-bucket-replication-role.role.arn


### PR DESCRIPTION
This got me stuck for a bit as I was using the code snippet from the readme which didn't work.

This should be using an alias for eu-west-1 but was pointing to an alias that didn't exist and had the wrong region.

Found an example here https://github.com/ministryofjustice/modernisation-platform/blob/2730fe5e3f2b0c4bd281869c843f980df5dbe631/terraform/environments/core-logging/s3_logging.tf#L294 that used eu-west-1 which all made sense to me in the end