### PR TITLE
updates-including-optional-versioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_s3_bucket" "default" {
         destination {
           bucket             = var.replication_enabled ? aws_s3_bucket.replication[0].arn : aws_s3_bucket.replication[0].arn
           storage_class      = "STANDARD"
-          replica_kms_key_id = (var.custom_replication_kms_key != "") ? var.custom_replication_kms_key : "arn:aws:kms:eu-west-1:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
+          replica_kms_key_id = (var.custom_replication_kms_key != "") ? var.custom_replication_kms_key : "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
         }
 
         source_selection_criteria {
@@ -112,7 +112,7 @@ resource "aws_s3_bucket" "default" {
   }
 
   versioning {
-    enabled = true
+    enabled = var.versioning_enabled
   }
 
   tags = var.tags
@@ -222,7 +222,7 @@ resource "aws_s3_bucket" "replication" {
   }
 
   versioning {
-    enabled = true
+    enabled = var.versioning_enabled_on_replication_bucket
   }
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,27 @@ variable "acl" {
   description = "Canned ACL to use on the bucket"
   default     = "private"
 }
+variable "versioning_enabled" {
+  type        = bool
+  description = "Activate S3 bucket versioning"
+  default     = true
+}
 
 variable "replication_enabled" {
-
   type        = bool
   description = "Activate S3 bucket replication"
+  default     = false
+}
+
+variable "replication_region" {
+  type        = string
+  description = "Region to create S3 replication bucket"
+  default     = "eu-west-1"
+}
+
+variable "versioning_enabled_on_replication_bucket" {
+  type        = bool
+  description = "Activate S3 bucket versioning on replication bucket"
   default     = false
 }
 


### PR DESCRIPTION
- versioning for main bucket and replication bucket is now optional
- replication bucket region is now configurable using the
  'replication_region' variable

this change provides the ability to disable versioning and specify the
region that the replication bucket will be created in