### PR TITLE
AWS Provider V4 Deprecations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       status = lookup(rule.value, "enabled", null)
 
       abort_incomplete_multipart_upload {
-        days_after_initiation = lookup(rule.value, "abort_incomplete_multipart_upload_days", null)
+        days_after_initiation = lookup(rule.value, "abort_incomplete_multipart_upload_days", "7")
       }
 
       # Max 1 block - expiration

--- a/main.tf
+++ b/main.tf
@@ -26,8 +26,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
     for_each = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
 
     content {
-      id     = lookup(rule.value, "id", null)
-      prefix = lookup(rule.value, "prefix", null)
+      id = lookup(rule.value, "id", null)
+      filter {
+        prefix = lookup(rule.value, "prefix", null)
+      }
       status = lookup(rule.value, "enabled", null)
 
       abort_incomplete_multipart_upload {


### PR DESCRIPTION
* Refactors `prefix` to sit inside a `filter` block in line with provider v4 updates
* Sets `abort_incomplete_multipart_upload` to seven days by default