### PR TITLE
Clean up false positives

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {}
 
 # Main S3 bucket, that is replicated from (rather than to)
+# KMS Encryption handled by aws_s3_bucket_server_side_encryption_configuration resource
+# Logging handled by aws_s3_bucket_logging resource
+# Versioning handled by aws_s3_bucket_versioning resource
+# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "default" {
   bucket        = var.bucket_name
   bucket_prefix = var.bucket_prefix

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.0.0, < 5.0.0"
+      version               = "~> 4.0"
       configuration_aliases = [aws.bucket-replication]
     }
   }


### PR DESCRIPTION
Some tfsec ignore messages have been added in line with changes to S3 bucket module that are yet to be accounted for in tfsec checks. For example, the bucket module no longer controls versioning in provider 4.0 onwards, but tfsec still checks for this.

Also set the provider constraint to be more in line with other modules.