### PR TITLE
added tfsec ignore for kms alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,8 @@ resource "aws_s3_bucket_replication_configuration" "default" {
   }
 }
 
+# AWS-provided KMS acceptable compromise in absence of customer provided key
+# tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   bucket = aws_s3_bucket.default.id
   rule {

--- a/main.tf
+++ b/main.tf
@@ -183,6 +183,8 @@ data "aws_iam_policy_document" "default" {
 }
 
 # Replication S3 bucket, to replicate to (rather than from)
+# Logging not deemed required for replication bucket
+# tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "replication" {
   count = var.replication_enabled ? 1 : 0
 


### PR DESCRIPTION
PR adds a `tfsec:ignore` statement around the use of AWS account local KMS key when the customer does not supply one of their own.