### PR TITLE
Fix unit tests

### DIFF
--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -22,7 +22,7 @@ locals {
 
   # Merge tags from the environment json file with additional ones
   tags = merge(
-    jsondecode(data.http.environments_file.body).tags,
+    jsondecode(data.http.environments_file.response_body).tags,
     { "is-production" = local.is-production },
     { "environment-name" = terraform.workspace },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }

--- a/test/unit-test/providers.tf
+++ b/test/unit-test/providers.tf
@@ -2,7 +2,7 @@
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/MemberInfrastructureAccess"
   }
 }
 


### PR DESCRIPTION
As noted in #59 , the unit tests fail without specifying the alias for the account to run the tests in. This PR hard codes that alias, and removes a deprecated attribute.