### PR TITLE
Harmonise creation of notification resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | Direct aws\_s3\_bucket resource with all attributes |
+| <a name="output_bucket_notifications"></a> [bucket\_notifications](#output\_bucket\_notifications) | n/a |
 | <a name="output_bucket_server_side_encryption"></a> [bucket\_server\_side\_encryption](#output\_bucket\_server\_side\_encryption) | Bucket server-side encryption configuration |
 <!-- END_TF_DOCS -->
 

--- a/main.tf
+++ b/main.tf
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification_replication" {
-  count  = var.replication_enabled && var.notification_events != [""] ? 1 : 0
+  count  = var.replication_enabled && var.notification_enabled ? 1 : 0
   bucket = aws_s3_bucket.replication[count.index]
 
   topic {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,7 @@ output "bucket_server_side_encryption" {
   value       = aws_s3_bucket_server_side_encryption_configuration.default
   description = "Bucket server-side encryption configuration"
 }
+
+output "bucket_notifications" {
+  value = [for i in aws_s3_bucket_notification.bucket_notification : i]
+}

--- a/test/s3_bucket_creation_test.go
+++ b/test/s3_bucket_creation_test.go
@@ -42,9 +42,7 @@ func TestS3Creation(t *testing.T) {
 	expectedStatus := "Enabled"
 	assert.Equal(t, expectedStatus, actualStatus)
 
-	// Verify bucket notification is created
-	//bucketNotification := terraform.Output(t, terraformOptions, "bucket_notification")
-	//if bucketNotification != "" {
-	//		fmt.Println("OK")
-	//} else {fmt.Println("NOOOO")}
+	// Verify that a bucket notification outputs a bucket name
+	bucketNotification := terraform.Output(t, terraformOptions, "bucket_notifications")
+	assert.Regexp(t, regexp.MustCompile(`unit-test-bucket*`), bucketNotification)
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -45,10 +45,10 @@ module "s3_with_notification" {
   providers = {
     aws.bucket-replication = aws
   }
-  bucket_prefix = "unit-test-bucket"
-  force_destroy = true
+  bucket_prefix        = "unit-test-bucket"
+  force_destroy        = true
   notification_enabled = true
-  notification_events = ["s3:ObjectCreated:*"]
+  notification_events  = ["s3:ObjectCreated:*"]
   notification_sns_arn = aws_sns_topic.topic.arn
-  tags          = local.tags
+  tags                 = local.tags
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -16,3 +16,8 @@ output "bucket_aes256" {
   value       = element(module.s3_with_AES256.bucket_server_side_encryption.rule[*].apply_server_side_encryption_by_default[0].sse_algorithm, 0)
   description = "SSE Algorithm"
 }
+
+output "bucket_notifications" {
+  value       = element(module.s3_with_notification.bucket_notifications, 0).bucket
+  description = "Retrieve name of bucket with notifications enabled"
+}


### PR DESCRIPTION
This PR does the following:
* Ensures the creation of a notification resource is handled consistently for both bucket types
* Adds an output for the notification resource if it is created
* Sets up a simple unit test to check that the notification resource has a bucket name in the output
* Lint the terraform content