### PR TITLE
#checkov:skip=CKV_AWS_26: it's part of the testing routine so doesn't require the check

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -35,6 +35,7 @@ data "aws_iam_policy_document" "topic" {
   }
 }
 resource "aws_sns_topic" "topic" {
+  #checkov:skip=CKV_AWS_26: "Ensure all data stored in the SNS topic is encrypted"
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -35,6 +35,7 @@ data "aws_iam_policy_document" "topic" {
   }
 }
 resource "aws_sns_topic" "topic" {
+  # Encryption not required as topic only available during test run
   #checkov:skip=CKV_AWS_26: "Ensure all data stored in the SNS topic is encrypted"
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -35,8 +35,7 @@ data "aws_iam_policy_document" "topic" {
   }
 }
 resource "aws_sns_topic" "topic" {
-  # Encryption not required as topic only available during test run
-  #checkov:skip=CKV_AWS_26: "Ensure all data stored in the SNS topic is encrypted"
+  #checkov:skip=CKV_AWS_26: "Encryption not required as topic only available during test run"
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json
 }


### PR DESCRIPTION
#checkov:skip=CKV_AWS_26: This has been reported as it's part of the testing routine so doesn't require the check really. It just picks up a JSON routine as a policy.