### PR TITLE
add Static analysis scan exception for module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ resource "aws_s3_bucket_policy" "default" {
 }
 # AWS-provided KMS acceptable compromise in absence of customer provided key
 # tfsec:ignore:aws-s3-encryption-customer-key
+#tfsec:ignore:avd-aws-0132 S3 encryption should use Custom Managed Keys, KMS is acceptable compromise 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   #checkov:skip=CKV2_AWS_67: "Ensure AWS S3 bucket encrypted with Customer Managed Key (CMK) has regular rotation"
 


### PR DESCRIPTION
- we're inheriting this tf static analysis scan failure via several modules 
- example [here](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/9711614567/job/26804697495 ) so just want to fix this
- tfsec:[avd-aws-0132](https://avd.aquasec.com/misconfig/avd-aws-0132) is new 
- adding this in line with other module level exceptions around key defaults