### PR TITLE
Revise bucket policy to enforce tls v1.2 or higher connections

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ data "aws_iam_policy_document" "default" {
   override_policy_documents = concat(var.bucket_policy, [data.aws_iam_policy_document.bucket_policy_v2.json])
 
   statement {
-    sid = "EnforceTLSv12orHigher"
+    sid     = "EnforceTLSv12orHigher"
     effect  = "Deny"
     actions = ["s3:*"]
     resources = [

--- a/main.tf
+++ b/main.tf
@@ -199,22 +199,21 @@ data "aws_iam_policy_document" "default" {
   override_policy_documents = concat(var.bucket_policy, [data.aws_iam_policy_document.bucket_policy_v2.json])
 
   statement {
+    sid = "EnforceTLSv12orHigher"
     effect  = "Deny"
     actions = ["s3:*"]
     resources = [
       aws_s3_bucket.default.arn,
       "${aws_s3_bucket.default.arn}/*"
     ]
-
     principals {
       identifiers = ["*"]
       type        = "AWS"
     }
-
     condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = [1.2]
     }
   }
 }


### PR DESCRIPTION
Bumping from just enforcing connections over HTTPS to ensuring the connection is using at least TLS v1.2 (and therefore inherently using https). This aligns with comments raised in various IT health checks. (see e.g. [here](https://repost.aws/knowledge-center/s3-enforce-modern-tls) for an example implementing the policy).