### PR TITLE
Resolve `aws_s3_bucket_lifecycle_configuration` error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
 
       dynamic "filter" {
         for_each = [lookup(rule.value, "prefix", null)]
-          content {
+        content {
           prefix = filter.value
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -53,9 +53,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
 
     content {
       id = lookup(rule.value, "id", null)
-      filter {
-        prefix = lookup(rule.value, "prefix", null)
+
+      dynamic "filter" {
+        for_each = [lookup(rule.value, "prefix", null)]
+          content {
+          prefix = filter.value
+        }
       }
+
       status = lookup(rule.value, "enabled", null)
 
       abort_incomplete_multipart_upload {

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -45,12 +45,6 @@ func TestS3Creation(t *testing.T) {
 	bucketNotification := terraform.Output(t, terraformOptions, "bucket_notifications")
 	assert.Regexp(t, regexp.MustCompile(`unit-test-bucket*`), bucketNotification)
 
-	// roleName := terraform.Output(t, terraformOptions, "role_name")
-	// assert.Regexp(t, regexp.MustCompile(`^AWSS3BucketReplication*`), roleName)
-
-	// policyName := terraform.Output(t, terraformOptions, "policy_name")
-	// assert.Regexp(t, regexp.MustCompile(`^AWSS3BucketReplicationPolicy*`), policyName)
-
 	// Retrieve the role_name output
 	roleName := terraform.Output(t, terraformOptions, "role_name")
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,7 @@ variable "lifecycle_rule" {
   default = [{
     id      = "main"
     enabled = "Enabled"
+    prefix  = ""
     tags = {
       rule      = "log"
       autoclean = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,6 @@ variable "lifecycle_rule" {
   default = [{
     id      = "main"
     enabled = "Enabled"
-    prefix  = ""
     tags = {
       rule      = "log"
       autoclean = "true"


### PR DESCRIPTION
This PR makes the presence of `prefix` inside the `filter {}` block conditional based on the existence of a prefix value being passed in through `var.lifecycle_rules` with no value being supplied by default so that all files are included.