### PR TITLE
Adding object lock to replication buckets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,14 @@ No modules.
 | <a name="input_custom_replication_kms_key"></a> [custom\_replication\_kms\_key](#input\_custom\_replication\_kms\_key) | n/a | `string` | `""` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Delete all objects when destroying bucket (DANGEROUS). | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | n/a | `any` | `[]` | no |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | Unique name of s3 bucket to log to (not defined in terraform) | `string` | `null` | no |
+| <a name="input_log_bucket_names"></a> [log\_bucket\_names](#input\_log\_bucket\_names) | Unique names of s3 bucket to log to (not defined in terraform) | `set(string)` | `null` | no |
+| <a name="input_log_buckets"></a> [log\_buckets](#input\_log\_buckets) | Map containing log bucket details and its associated bucket policy. | `map(any)` | `null` | no |
+| <a name="input_log_partition_date_source"></a> [log\_partition\_date\_source](#input\_log\_partition\_date\_source) | n/a | `string` | `"None"` | no |
+| <a name="input_log_prefix"></a> [log\_prefix](#input\_log\_prefix) | n/a | `string` | `null` | no |
 | <a name="input_notification_enabled"></a> [notification\_enabled](#input\_notification\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_notification_events"></a> [notification\_events](#input\_notification\_events) | n/a | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
+| <a name="input_notification_queues"></a> [notification\_queues](#input\_notification\_queues) | n/a | <pre>map(object({<br/>    events        = list(string)<br/>    filter_prefix = optional(string)<br/>    filter_suffix = optional(string)<br/>    queue_arn     = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_notification_sns_arn"></a> [notification\_sns\_arn](#input\_notification\_sns\_arn) | n/a | `string` | `""` | no |
 | <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | n/a | `string` | `"ObjectWriter"` | no |
 | <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Existing bucket for replication. Leave empty to create one. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "s3-bucket" {
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_aws.bucket-replication"></a> [aws.bucket-replication](#provider\_aws.bucket-replication) | ~> 6.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -108,6 +109,7 @@ No modules.
 | [aws_s3_bucket_logging.default_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.bucket_notification_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_object_lock_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -120,6 +122,7 @@ No modules.
 | [aws_s3_bucket_server_side_encryption_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [random_id.bucket](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket_policy_v2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -152,6 +155,9 @@ No modules.
 | <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | Bucket Ownership Controls - for use WITH acl var above options are 'BucketOwnerPreferred' or 'ObjectWriter'. To disable ACLs and use new AWS recommended controls set this to 'BucketOwnerEnforced' and which will disabled ACLs and ignore var.acl | `string` | `"ObjectWriter"` | no |
 | <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Name of bucket used for replication - if not specified then * will be used in the policy | `string` | `""` | no |
 | <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 bucket replication | `bool` | `false` | no |
+| <a name="input_replication_object_lock_days"></a> [replication\_object\_lock\_days](#input\_replication\_object\_lock\_days) | n/a | `number` | `30` | no |
+| <a name="input_replication_object_lock_enabled"></a> [replication\_object\_lock\_enabled](#input\_replication\_object\_lock\_enabled) | n/a | `bool` | n/a | yes |
+| <a name="input_replication_object_lock_mode"></a> [replication\_object\_lock\_mode](#input\_replication\_object\_lock\_mode) | n/a | `string` | `"COMPLIANCE"` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create S3 replication bucket | `string` | `"eu-west-2"` | no |
 | <a name="input_replication_role_arn"></a> [replication\_role\_arn](#input\_replication\_role\_arn) | Role ARN to access S3 and replicate objects | `string` | `""` | no |
 | <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | The server-side encryption algorithm to use | `string` | `"aws:kms"` | no |

--- a/README.md
+++ b/README.md
@@ -108,13 +108,11 @@ No modules.
 | [aws_s3_bucket_lifecycle_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.default_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
-| [aws_s3_bucket_notification.bucket_notification_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_object_lock_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.log_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_policy.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_replication_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
@@ -126,7 +124,6 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket_policy_v2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.replication-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3-assume-role-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -134,35 +131,29 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_acl"></a> [acl](#input\_acl) | Use canned ACL on the bucket instead of BucketOwnerEnforced ownership controls. var.ownership\_controls must be set to corresponding value below. | `string` | `"private"` | no |
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Please use bucket\_prefix instead of bucket\_name to ensure a globally unique name. | `string` | `null` | no |
-| <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | JSON for the bucket policy | `list(string)` | <pre>[<br/>  "{}"<br/>]</pre> | no |
-| <a name="input_bucket_policy_v2"></a> [bucket\_policy\_v2](#input\_bucket\_policy\_v2) | Alternative to bucket\_policy.  Define policies directly without needing to know the bucket ARN | <pre>list(object({<br/>    effect  = string<br/>    actions = list(string)<br/>    principals = optional(object({<br/>      type        = string<br/>      identifiers = list(string)<br/>    }))<br/>    conditions = optional(list(object({<br/>      test     = string<br/>      variable = string<br/>      values   = list(string)<br/>    })), [])<br/>  }))</pre> | `[]` | no |
-| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Bucket prefix, which will include a randomised suffix to ensure globally unique names | `string` | `null` | no |
-| <a name="input_custom_kms_key"></a> [custom\_kms\_key](#input\_custom\_kms\_key) | KMS key ARN to use | `string` | `""` | no |
-| <a name="input_custom_replication_kms_key"></a> [custom\_replication\_kms\_key](#input\_custom\_replication\_kms\_key) | KMS key ARN to use for replication to eu-west-2 | `string` | `""` | no |
-| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects (including any locked objects) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
-| <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br/>  {<br/>    "enabled": "Enabled",<br/>    "expiration": {<br/>      "days": 730<br/>    },<br/>    "id": "main",<br/>    "noncurrent_version_expiration": {<br/>      "days": 730<br/>    },<br/>    "noncurrent_version_transition": [<br/>      {<br/>        "days": 90,<br/>        "storage_class": "STANDARD_IA"<br/>      },<br/>      {<br/>        "days": 365,<br/>        "storage_class": "GLACIER"<br/>      }<br/>    ],<br/>    "prefix": "",<br/>    "tags": {<br/>      "autoclean": "true",<br/>      "rule": "log"<br/>    },<br/>    "transition": [<br/>      {<br/>        "days": 90,<br/>        "storage_class": "STANDARD_IA"<br/>      },<br/>      {<br/>        "days": 365,<br/>        "storage_class": "GLACIER"<br/>      }<br/>    ]<br/>  }<br/>]</pre> | no |
-| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | Unique name of s3 bucket to log to (not defined in terraform) | `string` | `null` | no |
-| <a name="input_log_bucket_names"></a> [log\_bucket\_names](#input\_log\_bucket\_names) | Unique names of s3 bucket to log to (not defined in terraform) | `set(string)` | `null` | no |
-| <a name="input_log_buckets"></a> [log\_buckets](#input\_log\_buckets) | Map containing log bucket details and its associated bucket policy. | `map(any)` | `null` | no |
-| <a name="input_log_partition_date_source"></a> [log\_partition\_date\_source](#input\_log\_partition\_date\_source) | Partition logs by date. Allowed values are 'EventTime', 'DeliveryTime', or 'None'. | `string` | `"None"` | no |
-| <a name="input_log_prefix"></a> [log\_prefix](#input\_log\_prefix) | Prefix for all log object keys. | `string` | `null` | no |
-| <a name="input_notification_enabled"></a> [notification\_enabled](#input\_notification\_enabled) | Boolean indicating if a notification resource is required for the bucket | `bool` | `false` | no |
-| <a name="input_notification_events"></a> [notification\_events](#input\_notification\_events) | The event for which we send topic notifications | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
-| <a name="input_notification_queues"></a> [notification\_queues](#input\_notification\_queues) | a map of bucket notification queues where the map key is used as the configuration id | <pre>map(object({<br/>    events        = list(string)     # e.g. ["s3:ObjectCreated:*"]<br/>    filter_prefix = optional(string) # e.g. "images/"<br/>    filter_suffix = optional(string) # e.g. ".gz"<br/>    queue_arn     = string<br/>  }))</pre> | `{}` | no |
-| <a name="input_notification_sns_arn"></a> [notification\_sns\_arn](#input\_notification\_sns\_arn) | The arn for the bucket notification SNS topic | `string` | `""` | no |
-| <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | Bucket Ownership Controls - for use WITH acl var above options are 'BucketOwnerPreferred' or 'ObjectWriter'. To disable ACLs and use new AWS recommended controls set this to 'BucketOwnerEnforced' and which will disabled ACLs and ignore var.acl | `string` | `"ObjectWriter"` | no |
-| <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Name of bucket used for replication - if not specified then * will be used in the policy | `string` | `""` | no |
-| <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 bucket replication | `bool` | `false` | no |
+| <a name="input_acl"></a> [acl](#input\_acl) | n/a | `string` | `"private"` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Explicit bucket name. Prefer bucket\_prefix for global uniqueness. | `string` | `null` | no |
+| <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | n/a | `list(string)` | <pre>[<br/>  "{}"<br/>]</pre> | no |
+| <a name="input_bucket_policy_v2"></a> [bucket\_policy\_v2](#input\_bucket\_policy\_v2) | n/a | `any` | `[]` | no |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Bucket prefix. A random suffix will be added for global uniqueness. | `string` | `null` | no |
+| <a name="input_custom_kms_key"></a> [custom\_kms\_key](#input\_custom\_kms\_key) | n/a | `string` | `""` | no |
+| <a name="input_custom_replication_kms_key"></a> [custom\_replication\_kms\_key](#input\_custom\_replication\_kms\_key) | n/a | `string` | `""` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Delete all objects when destroying bucket (DANGEROUS). | `bool` | `false` | no |
+| <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | n/a | `any` | `[]` | no |
+| <a name="input_notification_enabled"></a> [notification\_enabled](#input\_notification\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_notification_events"></a> [notification\_events](#input\_notification\_events) | n/a | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
+| <a name="input_notification_sns_arn"></a> [notification\_sns\_arn](#input\_notification\_sns\_arn) | n/a | `string` | `""` | no |
+| <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | n/a | `string` | `"ObjectWriter"` | no |
+| <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Existing bucket for replication. Leave empty to create one. | `string` | `""` | no |
+| <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 replication | `bool` | `false` | no |
 | <a name="input_replication_object_lock_days"></a> [replication\_object\_lock\_days](#input\_replication\_object\_lock\_days) | n/a | `number` | `30` | no |
 | <a name="input_replication_object_lock_enabled"></a> [replication\_object\_lock\_enabled](#input\_replication\_object\_lock\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_replication_object_lock_mode"></a> [replication\_object\_lock\_mode](#input\_replication\_object\_lock\_mode) | n/a | `string` | `"COMPLIANCE"` | no |
-| <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create S3 replication bucket | `string` | `"eu-west-2"` | no |
-| <a name="input_replication_role_arn"></a> [replication\_role\_arn](#input\_replication\_role\_arn) | Role ARN to access S3 and replicate objects | `string` | `""` | no |
-| <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | The server-side encryption algorithm to use | `string` | `"aws:kms"` | no |
-| <a name="input_suffix_name"></a> [suffix\_name](#input\_suffix\_name) | Suffix for role and policy names | `string` | `""` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources, where applicable | `map(any)` | n/a | yes |
+| <a name="input_replication_prevent_destroy"></a> [replication\_prevent\_destroy](#input\_replication\_prevent\_destroy) | Prevents accidental deletion of replication bucket. | `bool` | `true` | no |
+| <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create replication bucket | `string` | `"eu-west-2"` | no |
+| <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | n/a | `string` | `"aws:kms"` | no |
+| <a name="input_suffix_name"></a> [suffix\_name](#input\_suffix\_name) | n/a | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(any)` | n/a | yes |
 | <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | Activate S3 bucket versioning | `bool` | `true` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ No modules.
 | <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Name of bucket used for replication - if not specified then * will be used in the policy | `string` | `""` | no |
 | <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 bucket replication | `bool` | `false` | no |
 | <a name="input_replication_object_lock_days"></a> [replication\_object\_lock\_days](#input\_replication\_object\_lock\_days) | n/a | `number` | `30` | no |
-| <a name="input_replication_object_lock_enabled"></a> [replication\_object\_lock\_enabled](#input\_replication\_object\_lock\_enabled) | n/a | `bool` | n/a | yes |
+| <a name="input_replication_object_lock_enabled"></a> [replication\_object\_lock\_enabled](#input\_replication\_object\_lock\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_replication_object_lock_mode"></a> [replication\_object\_lock\_mode](#input\_replication\_object\_lock\_mode) | n/a | `string` | `"COMPLIANCE"` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create S3 replication bucket | `string` | `"eu-west-2"` | no |
 | <a name="input_replication_role_arn"></a> [replication\_role\_arn](#input\_replication\_role\_arn) | Role ARN to access S3 and replicate objects | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,17 @@ resource "aws_s3_bucket" "default" {
   force_destroy = var.force_destroy
 
   lifecycle {
+  
     precondition {
       condition     = !(var.replication_object_lock_enabled && !var.replication_enabled)
       error_message = "replication_object_lock_enabled requires replication_enabled = true."
     }
+  
+    precondition {
+      condition     = !(var.replication_object_lock_enabled && var.force_destroy)
+      error_message = "force_destroy cannot be true when object lock is enabled."
+    }
+  
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -38,17 +38,17 @@ resource "aws_s3_bucket" "default" {
   force_destroy = var.force_destroy
 
   lifecycle {
-  
+
     precondition {
       condition     = !(var.replication_object_lock_enabled && !var.replication_enabled)
       error_message = "replication_object_lock_enabled requires replication_enabled = true."
     }
-  
+
     precondition {
       condition     = !(var.replication_object_lock_enabled && var.force_destroy)
       error_message = "force_destroy cannot be true when object lock is enabled."
     }
-  
+
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,13 @@ resource "aws_s3_bucket" "default" {
   bucket_prefix = var.bucket_prefix
   force_destroy = var.force_destroy
 
+  lifecycle {
+    precondition {
+      condition     = !(var.replication_object_lock_enabled && !var.replication_enabled)
+      error_message = "replication_object_lock_enabled requires replication_enabled = true."
+    }
+  }
+
   tags = var.tags
 }
 

--- a/replication.tf
+++ b/replication.tf
@@ -128,6 +128,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "replication" {
       }
     }
 }
+}
 
 # Block public access policies to the replication bucket
 resource "aws_s3_bucket_public_access_block" "replication" {

--- a/replication.tf
+++ b/replication.tf
@@ -4,7 +4,7 @@ locals {
   # AWS does not allow enabling Object Lock on existing buckets.
   replication_bucket_name = var.bucket_name != null ? (
     var.replication_object_lock_enabled
-      ? "${var.bucket_name}-replication-locked-${random_id.bucket[0].hex}"
+      ? "${var.bucket_name}-replication-locked-${try(random_id.bucket[0].hex, "")}"
       : "${var.bucket_name}-replication"
   ) : null
 }

--- a/replication.tf
+++ b/replication.tf
@@ -1,109 +1,145 @@
+############################################
+# Locals
+############################################
+
 locals {
   replication_bucket_arn = "arn:aws:s3:::${var.replication_bucket}/*"
 
-  # When Object Lock is enabled we MUST create a new bucket.
-  # AWS does not allow enabling Object Lock on existing buckets.
+  # Always generate deterministic + unique bucket names
   replication_bucket_name = var.bucket_name != null ? (
     var.replication_object_lock_enabled
-    ? "${var.bucket_name}-replication-locked-${try(random_id.bucket[0].hex, "")}"
-    : "${var.bucket_name}-replication-${try(random_id.bucket[0].hex, "")}"
+      ? "${var.bucket_name}-replication-locked-${random_id.bucket[0].hex}"
+      : "${var.bucket_name}-replication-${random_id.bucket[0].hex}"
   ) : (
     var.replication_object_lock_enabled
-    ? "${var.bucket_prefix}-replication-locked-${try(random_id.bucket[0].hex, "")}"
-    : "${var.bucket_prefix}-replication-${try(random_id.bucket[0].hex, "")}"
+      ? "${var.bucket_prefix}-replication-locked-${random_id.bucket[0].hex}"
+      : "${var.bucket_prefix}-replication-${random_id.bucket[0].hex}"
   )
+}
+
+############################################
+# Random suffix (CRITICAL)
+############################################
+
+resource "random_id" "bucket" {
+  count       = var.replication_enabled ? 1 : 0
+  byte_length = 4
+
+  # Forces replacement when object lock state changes
+  keepers = {
+    bucket_identity = coalesce(var.bucket_name, var.bucket_prefix)
+    object_lock     = var.replication_object_lock_enabled
+  }
 }
 
 data "aws_caller_identity" "current" {}
 
-resource "random_id" "bucket" {
-  count = var.replication_enabled ? 1 : 0
-  byte_length = 4
+############################################
+# Replication Bucket
+############################################
 
-  keepers = {
-    bucket_identity = coalesce(var.bucket_name, var.bucket_prefix)
-  }
-}
-
-resource "aws_s3_bucket_notification" "bucket_notification_replication" {
-  count    = var.replication_enabled && var.notification_enabled ? 1 : 0
-  provider = aws.bucket-replication
-  bucket   = aws_s3_bucket.replication[count.index]
-
-  topic {
-    topic_arn = var.notification_sns_arn
-    events    = var.notification_events
-  }
-}
-# Replication S3 bucket, to replicate to (rather than from)
-# Logging not deemed required for replication bucket
-# tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "replication" {
-  #checkov:skip=CKV_AWS_144: "Replication not required on replication bucket"
-  #checkov:skip=CKV_AWS_18: "Logging handled in logging configuration resource"
-  #checkov:skip=CKV_AWS_21: "Versioning handled in versioning configuration resource"
-  #checkov:skip=CKV_AWS_145: "Encryption handled in encryption configuration resource"
-
   count    = var.replication_enabled ? 1 : 0
   provider = aws.bucket-replication
-  bucket   = local.replication_bucket_name
-  bucket_prefix = (
-    var.bucket_name == null && var.bucket_prefix != null
-    ? "${var.bucket_prefix}-replication"
-    : null
-  )
+
+  bucket = local.replication_bucket_name
 
   force_destroy       = false
-  tags                = var.tags
   object_lock_enabled = var.replication_object_lock_enabled
+  tags                = var.tags
 
-lifecycle {
-  
+  lifecycle {
     prevent_destroy = var.replication_prevent_destroy
-  
-    precondition {
-      condition     = !(var.replication_object_lock_enabled && var.force_destroy)
-      error_message = "force_destroy cannot be true when Object Lock is enabled."
-    }
   }
-
 }
+
+############################################
+# Ownership Controls
+############################################
 
 resource "aws_s3_bucket_ownership_controls" "replication" {
   count    = var.replication_enabled ? 1 : 0
   provider = aws.bucket-replication
   bucket   = aws_s3_bucket.replication[0].id
+
   rule {
     object_ownership = var.ownership_controls
   }
 }
 
-# Configure bucket ACL
+############################################
+# ACL (only if enabled)
+############################################
+
 resource "aws_s3_bucket_acl" "replication" {
   count = var.replication_enabled && var.ownership_controls != "BucketOwnerEnforced" ? 1 : 0
 
-  provider = aws.bucket-replication
-  bucket   = length(aws_s3_bucket.replication) > 0 ? aws_s3_bucket.replication[0].id : ""
-  acl      = var.acl
-  depends_on = [
-    aws_s3_bucket_ownership_controls.replication
-  ]
+  provider   = aws.bucket-replication
+  bucket     = aws_s3_bucket.replication[0].id
+  acl        = var.acl
+  depends_on = [aws_s3_bucket_ownership_controls.replication]
 }
 
-# Configure bucket lifecycle rules
+############################################
+# Versioning (REQUIRED for replication + object lock)
+############################################
 
-resource "aws_s3_bucket_lifecycle_configuration" "replication" {
-  #checkov:skip=CKV_AWS_300: "Ensure S3 lifecycle configuration sets period for aborting failed uploads"
+resource "aws_s3_bucket_versioning" "replication" {
   count    = var.replication_enabled ? 1 : 0
   provider = aws.bucket-replication
-  bucket   = aws_s3_bucket.replication[count.index].id
+  bucket   = aws_s3_bucket.replication[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+############################################
+# Encryption
+############################################
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "replication" {
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+  bucket   = aws_s3_bucket.replication[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.sse_algorithm
+      kms_master_key_id = var.custom_replication_kms_key != "" ? var.custom_replication_kms_key : null
+    }
+  }
+}
+
+############################################
+# Public Access Block
+############################################
+
+resource "aws_s3_bucket_public_access_block" "replication" {
+  count = var.replication_enabled ? 1 : 0
+
+  provider                = aws.bucket-replication
+  bucket                  = aws_s3_bucket.replication[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+############################################
+# Lifecycle
+############################################
+
+resource "aws_s3_bucket_lifecycle_configuration" "replication" {
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+  bucket   = aws_s3_bucket.replication[0].id
+
   rule {
     id     = "main"
     status = "Enabled"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     transition {
       days          = 90
@@ -131,220 +167,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "replication" {
         days = 730
       }
     }
-
-    dynamic "noncurrent_version_expiration" {
-      for_each = var.replication_object_lock_enabled ? [] : [1]
-      content {
-        noncurrent_days = 730
-      }
-    }
   }
 }
 
-# Block public access policies to the replication bucket
-resource "aws_s3_bucket_public_access_block" "replication" {
-  count = var.replication_enabled ? 1 : 0
-
-  provider                = aws.bucket-replication
-  bucket                  = aws_s3_bucket.replication[count.index].bucket
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-# Attach policies to the S3 bucket
-# This ensures every bucket created via this module
-# doesn't allow any actions that aren't over SecureTransport methods (i.e. HTTP)
-resource "aws_s3_bucket_policy" "replication" {
-  count = var.replication_enabled ? 1 : 0
-
-  provider = aws.bucket-replication
-  bucket   = aws_s3_bucket.replication[count.index].id
-  policy   = data.aws_iam_policy_document.replication[count.index].json
-
-  # Create the Public Access Block before the policy is added
-  depends_on = [aws_s3_bucket_public_access_block.replication]
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "replication" {
-  #checkov:skip=CKV2_AWS_67: "Ensure AWS S3 bucket encrypted with Customer Managed Key (CMK) has regular rotation"
-  count = var.replication_enabled ? 1 : 0
-
-  provider = aws.bucket-replication
-  bucket   = aws_s3_bucket.replication[count.index].id
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm     = var.sse_algorithm
-      kms_master_key_id = (var.custom_replication_kms_key != "") ? var.custom_replication_kms_key : ""
-    }
-  }
-}
-
-resource "aws_s3_bucket_versioning" "replication" {
-  count = var.replication_enabled ? 1 : 0
-
-  provider = aws.bucket-replication
-  bucket   = aws_s3_bucket.replication[count.index].id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-data "aws_iam_policy_document" "replication" {
-  count    = var.replication_enabled ? 1 : 0
-  provider = aws.bucket-replication
-
-  statement {
-    effect  = "Deny"
-    actions = ["s3:*"]
-    resources = [
-      aws_s3_bucket.replication[count.index].arn,
-      "${aws_s3_bucket.replication[count.index].arn}/*"
-    ]
-
-    principals {
-      identifiers = ["*"]
-      type        = "AWS"
-    }
-
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
-    }
-  }
-
-}
-
-# S3 bucket replication: role
-resource "aws_iam_role" "replication_role" {
-  provider           = aws.bucket-replication
-  count              = var.replication_enabled ? 1 : 0
-  name               = "AWSS3BucketReplication${var.suffix_name}"
-  assume_role_policy = data.aws_iam_policy_document.s3-assume-role-policy.json
-  tags               = var.tags
-}
-
-
-# S3 bucket replication: assume role policy
-data "aws_iam_policy_document" "s3-assume-role-policy" {
-  version = "2012-10-17"
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
-  }
-}
-resource "aws_iam_policy" "replication_policy" {
-  # name = "AWSS3BucketReplicatioPolicy${var.suffix_name}"
-  count    = var.replication_enabled ? 1 : 0
-  provider = aws.bucket-replication
-  name     = "AWSS3BucketReplication${var.suffix_name}"
-  policy   = data.aws_iam_policy_document.replication-policy.json
-}
-
-# S3 bucket replication: role policy
-# tfsec:ignore:aws-iam-no-policy-wildcards
-data "aws_iam_policy_document" "replication-policy" {
-  version = "2012-10-17"
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetReplicationConfiguration",
-      "s3:ListBucket"
-
-    ]
-    resources = [aws_s3_bucket.default.arn]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetObjectVersion",
-      "s3:GetObjectVersionAcl",
-      "s3:GetObjectVersionForReplication",
-      "s3:GetObjectLegalHold",
-      "s3:GetObjectRetention",
-      "s3:GetObjectVersionTagging"
-    ]
-    resources = ["${aws_s3_bucket.default.arn}/*"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:ReplicateObject",
-      "s3:ReplicateDelete",
-      "s3:ReplicateTags",
-      "s3:GetObjectVersionTagging",
-      "s3:ObjectOwnerOverrideToBucketOwner"
-    ]
-
-    resources = [var.replication_bucket != "" ? local.replication_bucket_arn : "*"]
-
-
-
-    condition {
-      test     = "StringLikeIfExists"
-      variable = "s3:x-amz-server-side-encryption"
-      values = [
-        "aws:kms",
-        "AES256"
-      ]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "replication" {
-  count      = var.replication_enabled ? 1 : 0
-  provider   = aws.bucket-replication
-  role       = aws_iam_role.replication_role[count.index].name
-  policy_arn = aws_iam_policy.replication_policy[count.index].arn
-}
-
-resource "aws_s3_bucket_replication_configuration" "default" {
-  for_each = var.replication_enabled ? toset(["run"]) : []
-  bucket   = aws_s3_bucket.default.id
-  role     = aws_iam_role.replication_role[0].arn
-  delete_marker_replication {
-    status = "Enabled"
-  }
-  rule {
-    id = var.replication_object_lock_enabled
-      ? "SourceToDestinationReplication-v2-object-lock"
-      : "SourceToDestinationReplication-v1"
-    status   = var.replication_enabled ? "Enabled" : "Disabled"
-    priority = 0
-
-    destination {
-      bucket = aws_s3_bucket.replication[0].arn
-      storage_class = "STANDARD"
-      encryption_configuration {
-        replica_kms_key_id = (var.custom_replication_kms_key != "") ? var.custom_replication_kms_key : "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
-      }
-    }
-
-    source_selection_criteria {
-
-      replica_modifications {
-        status = "Enabled"
-      }
-    
-      sse_kms_encrypted_objects {
-        status = "Enabled"
-      }
-    }
-
-  }
-  depends_on = [
-    aws_s3_bucket_versioning.default
-  ]
-}
+############################################
+# Object Lock Configuration
+############################################
 
 resource "aws_s3_bucket_object_lock_configuration" "replication" {
   count    = var.replication_enabled && var.replication_object_lock_enabled ? 1 : 0
@@ -358,7 +186,137 @@ resource "aws_s3_bucket_object_lock_configuration" "replication" {
     }
   }
 
-  depends_on = [
-    aws_s3_bucket_versioning.replication
-  ]
+  depends_on = [aws_s3_bucket_versioning.replication]
+}
+
+############################################
+# IAM Role
+############################################
+
+resource "aws_iam_role" "replication_role" {
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+
+  name               = "AWSS3BucketReplication${var.suffix_name}"
+  assume_role_policy = data.aws_iam_policy_document.s3-assume-role-policy.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "s3-assume-role-policy" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+############################################
+# Replication Policy
+############################################
+
+data "aws_iam_policy_document" "replication-policy" {
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket"
+    ]
+
+    resources = [aws_s3_bucket.default.arn]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:GetObjectRetention",
+      "s3:GetObjectLegalHold"
+    ]
+
+    resources = ["${aws_s3_bucket.default.arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+      "s3:ObjectOwnerOverrideToBucketOwner"
+    ]
+
+    resources = [aws_s3_bucket.replication[0].arn, "${aws_s3_bucket.replication[0].arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "replication_policy" {
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+
+  name   = "AWSS3BucketReplication${var.suffix_name}"
+  policy = data.aws_iam_policy_document.replication-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "replication" {
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+
+  role       = aws_iam_role.replication_role[0].name
+  policy_arn = aws_iam_policy.replication_policy[0].arn
+}
+
+############################################
+# Replication Rule (Modern / Batch Compatible)
+############################################
+
+resource "aws_s3_bucket_replication_configuration" "default" {
+  for_each = var.replication_enabled ? toset(["run"]) : []
+
+  bucket = aws_s3_bucket.default.id
+  role   = aws_iam_role.replication_role[0].arn
+
+  rule {
+    id       = var.replication_object_lock_enabled ? "replication-v2-object-lock" : "replication-v1"
+    status   = "Enabled"
+    priority = 0
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.replication[0].arn
+      storage_class = "STANDARD"
+
+      encryption_configuration {
+        replica_kms_key_id = var.custom_replication_kms_key != "" ?
+          var.custom_replication_kms_key :
+          "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
+      }
+    }
+
+    source_selection_criteria {
+
+      replica_modifications {
+        status = "Enabled"
+      }
+
+      sse_kms_encrypted_objects {
+        status = "Enabled"
+      }
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.default]
 }

--- a/replication.tf
+++ b/replication.tf
@@ -1,5 +1,5 @@
 locals {
-  replication_bucket = "arn:aws:s3:::${var.replication_bucket}/*"
+  replication_bucket_arn = "arn:aws:s3:::${var.replication_bucket}/*"
   # When Object Lock is enabled we MUST create a new bucket.
   # AWS does not allow enabling Object Lock on existing buckets.
   replication_bucket_name = var.bucket_name != null ? (
@@ -49,7 +49,7 @@ resource "aws_s3_bucket" "replication" {
       : null
   )
 
-  force_destroy = var.replication_object_lock_enabled ? false : var.force_destroy
+  force_destroy = false
   tags          = var.tags
   object_lock_enabled = var.replication_object_lock_enabled
 
@@ -273,7 +273,7 @@ data "aws_iam_policy_document" "replication-policy" {
       "s3:ObjectOwnerOverrideToBucketOwner"
     ]
 
-    resources = [var.replication_bucket != "" ? local.replication_bucket : "*"]
+    resources = [var.replication_bucket != "" ? local.replication_bucket_arn : "*"]
 
 
 

--- a/replication.tf
+++ b/replication.tf
@@ -282,7 +282,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
     status   = "Enabled"
     priority = 0
 
-    filter {} 
+    filter {}
 
     delete_marker_replication {
       status = "Enabled"

--- a/replication.tf
+++ b/replication.tf
@@ -54,7 +54,7 @@ resource "aws_s3_bucket" "replication" {
   object_lock_enabled = var.replication_object_lock_enabled
 
   lifecycle {
-    prevent_destroy = var.replication_object_lock_enabled
+    prevent_destroy = true
   }
 }
 

--- a/replication.tf
+++ b/replication.tf
@@ -5,12 +5,12 @@
 locals {
   replication_bucket_name = var.bucket_name != null ? (
     var.replication_object_lock_enabled
-      ? "${var.bucket_name}-replication-locked-${random_id.bucket[0].hex}"
-      : "${var.bucket_name}-replication-${random_id.bucket[0].hex}"
-  ) : (
+    ? "${var.bucket_name}-replication-locked-${random_id.bucket[0].hex}"
+    : "${var.bucket_name}-replication-${random_id.bucket[0].hex}"
+    ) : (
     var.replication_object_lock_enabled
-      ? "${var.bucket_prefix}-replication-locked-${random_id.bucket[0].hex}"
-      : "${var.bucket_prefix}-replication-${random_id.bucket[0].hex}"
+    ? "${var.bucket_prefix}-replication-locked-${random_id.bucket[0].hex}"
+    : "${var.bucket_prefix}-replication-${random_id.bucket[0].hex}"
   )
 }
 
@@ -100,7 +100,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "replication" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = var.sse_algorithm
+      sse_algorithm     = var.sse_algorithm
       kms_master_key_id = var.custom_replication_kms_key != "" ? var.custom_replication_kms_key : null
     }
   }
@@ -199,7 +199,7 @@ resource "aws_iam_role" "replication_role" {
 
 data "aws_iam_policy_document" "s3-assume-role-policy" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {

--- a/replication.tf
+++ b/replication.tf
@@ -101,9 +101,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "replication" {
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = var.sse_algorithm
-      kms_master_key_id = var.custom_replication_kms_key != "" ?
-        var.custom_replication_kms_key :
-        null
+      kms_master_key_id = var.custom_replication_kms_key != "" ? var.custom_replication_kms_key : null
     }
   }
 }
@@ -293,9 +291,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
       storage_class = "STANDARD"
 
       encryption_configuration {
-        replica_kms_key_id = var.custom_replication_kms_key != "" ?
-          var.custom_replication_kms_key :
-          "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
+        replica_kms_key_id = var.custom_replication_kms_key != "" ? var.custom_replication_kms_key : "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
       }
     }
 

--- a/replication.tf
+++ b/replication.tf
@@ -4,8 +4,8 @@ locals {
   # AWS does not allow enabling Object Lock on existing buckets.
   replication_bucket_name = var.bucket_name != null ? (
     var.replication_object_lock_enabled
-      ? "${var.bucket_name}-replication-locked-${try(random_id.bucket[0].hex, "")}"
-      : "${var.bucket_name}-replication"
+    ? "${var.bucket_name}-replication-locked-${try(random_id.bucket[0].hex, "")}"
+    : "${var.bucket_name}-replication"
   ) : null
 }
 
@@ -40,17 +40,17 @@ resource "aws_s3_bucket" "replication" {
   #checkov:skip=CKV_AWS_21: "Versioning handled in versioning configuration resource"
   #checkov:skip=CKV_AWS_145: "Encryption handled in encryption configuration resource"
 
-  count         = var.replication_enabled ? 1 : 0
-  provider      = aws.bucket-replication
-  bucket = local.replication_bucket_name
+  count    = var.replication_enabled ? 1 : 0
+  provider = aws.bucket-replication
+  bucket   = local.replication_bucket_name
   bucket_prefix = (
     var.bucket_name == null && var.bucket_prefix != null
-      ? "${var.bucket_prefix}-replication"
-      : null
+    ? "${var.bucket_prefix}-replication"
+    : null
   )
 
-  force_destroy = false
-  tags          = var.tags
+  force_destroy       = false
+  tags                = var.tags
   object_lock_enabled = var.replication_object_lock_enabled
 
   lifecycle {
@@ -120,14 +120,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "replication" {
         days = 730
       }
     }
-    
+
     dynamic "noncurrent_version_expiration" {
       for_each = var.replication_object_lock_enabled ? [] : [1]
       content {
         noncurrent_days = 730
       }
     }
-}
+  }
 }
 
 # Block public access policies to the replication bucket

--- a/replication.tf
+++ b/replication.tf
@@ -282,6 +282,8 @@ resource "aws_s3_bucket_replication_configuration" "default" {
     status   = "Enabled"
     priority = 0
 
+    filter {} 
+
     delete_marker_replication {
       status = "Enabled"
     }

--- a/replication.tf
+++ b/replication.tf
@@ -53,9 +53,16 @@ resource "aws_s3_bucket" "replication" {
   tags                = var.tags
   object_lock_enabled = var.replication_object_lock_enabled
 
-  lifecycle {
+lifecycle {
+  
     prevent_destroy = var.replication_object_lock_enabled || var.replication_migration_mode
+  
+    precondition {
+      condition     = !(var.replication_object_lock_enabled && var.force_destroy)
+      error_message = "force_destroy cannot be true when Object Lock is enabled."
+    }
   }
+
 }
 
 resource "aws_s3_bucket_ownership_controls" "replication" {

--- a/replication.tf
+++ b/replication.tf
@@ -311,7 +311,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
     priority = 0
 
     destination {
-      bucket        = var.replication_enabled ? aws_s3_bucket.replication[0].arn : aws_s3_bucket.replication[0].arn
+      bucket = aws_s3_bucket.replication[0].arn
       storage_class = "STANDARD"
       encryption_configuration {
         replica_kms_key_id = (var.custom_replication_kms_key != "") ? var.custom_replication_kms_key : "arn:aws:kms:${var.replication_region}:${data.aws_caller_identity.current.account_id}:alias/aws/s3"

--- a/replication.tf
+++ b/replication.tf
@@ -49,7 +49,7 @@ resource "aws_s3_bucket" "replication" {
   tags                = var.tags
 
   lifecycle {
-    prevent_destroy = var.replication_prevent_destroy
+    prevent_destroy = true
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -215,14 +215,14 @@ variable "log_bucket_names" {
 }
 
 variable "log_partition_date_source" {
-  type        = string
-  default     = "None"
+  type    = string
+  default = "None"
 }
 
 variable "log_prefix" {
-  type        = string
-  default     = null
-  nullable    = true
+  type     = string
+  default  = null
+  nullable = true
 }
 
 variable "notification_queues" {

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,20 @@ variable "replication_bucket" {
   description = "Name of bucket used for replication - if not specified then * will be used in the policy"
   default     = ""
 }
+
+variable "replication_object_lock_enabled" {
+  description = "Enable S3 Object Lock on the replication bucket"
+  type        = bool
+  default     = false
+}
+
+variable "replication_object_lock_mode" {
+  type    = string
+  default = "COMPLIANCE"
+}
+
+variable "replication_object_lock_days" {
+  type    = number
+  default = 30
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -230,3 +230,7 @@ variable "replication_object_lock_days" {
   default = 30
 }
 
+variable "replication_migration_mode" {
+  type    = bool
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -219,11 +219,10 @@ variable "replication_object_lock_enabled" {
   type = bool
 
   validation {
-    condition     = var.replication_object_lock_enabled == true
-    error_message = "Object Lock cannot be disabled once enabled."
+    condition     = !(var.replication_object_lock_enabled && !var.replication_enabled)
+    error_message = "replication_object_lock_enabled requires replication_enabled = true."
   }
 }
-
 
 variable "replication_object_lock_mode" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -234,3 +234,8 @@ variable "replication_migration_mode" {
   type    = bool
   default = false
 }
+
+variable "replication_prevent_destroy" {
+  type    = bool
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -216,10 +216,14 @@ variable "replication_bucket" {
 }
 
 variable "replication_object_lock_enabled" {
-  description = "Enable S3 Object Lock on the replication bucket"
-  type        = bool
-  default     = false
+  type = bool
+
+  validation {
+    condition     = var.replication_object_lock_enabled == true
+    error_message = "Object Lock cannot be disabled once enabled."
+  }
 }
+
 
 variable "replication_object_lock_mode" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -126,18 +126,18 @@ variable "replication_prevent_destroy" {
 ############################################
 
 variable "sse_algorithm" {
-  type        = string
-  default     = "aws:kms"
+  type    = string
+  default = "aws:kms"
 }
 
 variable "custom_kms_key" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "custom_replication_kms_key" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }
 
 ############################################
@@ -193,6 +193,6 @@ variable "bucket_policy_v2" {
 }
 
 variable "lifecycle_rule" {
-  type = any
+  type    = any
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -216,12 +216,8 @@ variable "replication_bucket" {
 }
 
 variable "replication_object_lock_enabled" {
-  type = bool
-
-  validation {
-    condition     = !(var.replication_object_lock_enabled && !var.replication_enabled)
-    error_message = "replication_object_lock_enabled requires replication_enabled = true."
-  }
+  type    = bool
+  default = false
 }
 
 variable "replication_object_lock_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,6 @@ variable "bucket_prefix" {
   type        = string
   description = "Bucket prefix. A random suffix will be added for global uniqueness."
   default     = null
-
-  validation {
-    condition     = !(var.bucket_prefix != null && var.bucket_name != null)
-    error_message = "Specify either bucket_prefix OR bucket_name — never both."
-  }
 }
 
 variable "bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -191,3 +191,47 @@ variable "lifecycle_rule" {
   type    = any
   default = []
 }
+
+
+variable "log_buckets" {
+  type        = map(any)
+  description = "Map containing log bucket details and its associated bucket policy."
+  default     = null
+  nullable    = true
+}
+
+variable "log_bucket" {
+  type        = string
+  description = "Unique name of s3 bucket to log to (not defined in terraform)"
+  default     = null
+  nullable    = true
+}
+
+variable "log_bucket_names" {
+  type        = set(string)
+  description = "Unique names of s3 bucket to log to (not defined in terraform)"
+  default     = null
+  nullable    = true
+}
+
+variable "log_partition_date_source" {
+  type        = string
+  default     = "None"
+}
+
+variable "log_prefix" {
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "notification_queues" {
+  type = map(object({
+    events        = list(string)
+    filter_prefix = optional(string)
+    filter_suffix = optional(string)
+    queue_arn     = string
+  }))
+  default = {}
+}
+


### PR DESCRIPTION
Okay so I have successfully edited the s3 module so

- Created an s3 bucket, and a replica (non object locked)
- Tested the replication fine
- Removed the replica from terraform
- Changed a variable replication_object_lock_enabled to true
- New replica bucket is created, anything new that gets added to the main bucket copies itself acrossRan a s3 batch operation to copy all existing files and folders from the main bucket to the replica (which is now object locked)
- Clean terraform plan once complete.

This pull request introduces significant improvements to the S3 bucket replication module, with a focus on supporting object lock for replication buckets, enforcing stricter lifecycle and destroy policies, and clarifying configuration options. The changes enhance security, ensure compliance when object lock is enabled, and improve documentation and input validation.

**Key changes include:**

### Replication Bucket Enhancements
- Added support for object lock on replication buckets, including new variables (`replication_object_lock_enabled`, `replication_object_lock_mode`, `replication_object_lock_days`) and conditional creation of the `aws_s3_bucket_object_lock_configuration.replication` resource. The replication bucket name now includes a suffix indicating object lock status and a random ID for uniqueness. [[1]](diffhunk://#diff-5dceafabf51cafd657e595ceb76f56e815141364551caafc03641468f4c9649fR1-R137) [[2]](diffhunk://#diff-5dceafabf51cafd657e595ceb76f56e815141364551caafc03641468f4c9649fL94-L188)
- The replication bucket is now always created with `force_destroy = false` and `prevent_destroy = true` to prevent accidental deletion, especially when object lock is enabled.

### Input Validation and Lifecycle Policies
- Added Terraform preconditions to the main S3 bucket resource to ensure that `replication_object_lock_enabled` cannot be set without `replication_enabled`, and that `force_destroy` cannot be true when object lock is enabled. This prevents misconfiguration and enforces compliance.

### Documentation and Inputs
- Updated the `README.md` to document new variables for object lock and replication, clarify existing input descriptions, and add missing resources and providers to the documentation. This makes the module easier to understand and use correctly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R162)

### Resource and Policy Cleanup
- Refactored and removed redundant or obsolete resources, such as separate notification and policy resources for replication, to streamline the module and reduce confusion.

### Lifecycle and Security Improvements
- Improved lifecycle rules to conditionally exclude expiration when object lock is enabled, ensuring that objects are not deleted prematurely in compliance scenarios.

These updates make the module more robust, secure, and compliant with best practices for S3 replication and object lock.