### PR TITLE
add AWS-managed KMS migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,15 @@ When using KMS encryption:
   - the correct KMS key must be used
   - uploads must explicitly include SSE-KMS headers
 
+#### AWS-managed S3 KMS key (`aws/s3`) buckets
+
+Buckets currently relying on AWS-managed S3 KMS keys (`aws/s3`) are not supported in `aws:kms` mode unless they are migrated to a customer-managed KMS key.
+
+Buckets currently using AWS-managed S3 KMS keys should continue using KMS encryption after migration, either:
+
+- with strict SSE-KMS request-header enforcement (default), or
+- with `enforce_kms_request_headers = false` to support uploaders that rely on bucket default SSE-KMS encryption and cannot send explicit SSE-KMS headers.
+
 #### Required upload headers:
 
 - `x-amz-server-side-encryption: aws:kms`


### PR DESCRIPTION
## A reference to the issue / Description of it

Adds additional README guidance for buckets currently using AWS-managed S3 KMS keys (`aws/s3`).

---

## How does this PR fix the problem?

This PR documents migration guidance for buckets moving to the new default SSE-KMS behaviour introduced in v10.

The README now clarifies:

- AWS-managed S3 KMS keys (`aws/s3`) are not supported in `aws:kms` mode
- Existing buckets must migrate to a customer-managed KMS key
- Uploaders can either:
  - use strict SSE-KMS request-header enforcement (default), or
  - use `enforce_kms_request_headers = false` for compatibility scenarios where explicit SSE-KMS headers are not sent

---

## How has this been tested?

- README review only

---

## Deployment Plan / Instructions

### Will this deployment impact the platform and / or services on it?

- No

Documentation-only change.

---

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

---

## Additional comments (if any)