### PR TITLE
Add Object Lock support for replication buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ No modules.
 | [aws_s3_bucket_logging.default_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.bucket_notification_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_object_lock_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_object_lock_configuration.s3_bucket_object_lock_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
@@ -168,6 +169,7 @@ No modules.
 | <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | Bucket Ownership Controls - for use WITH acl var above options are 'BucketOwnerPreferred' or 'ObjectWriter'. To disable ACLs and use new AWS recommended controls set this to 'BucketOwnerEnforced' and which will disabled ACLs and ignore var.acl | `string` | `"ObjectWriter"` | no |
 | <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Name of bucket used for replication - if not specified then * will be used in the policy | `string` | `""` | no |
 | <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 bucket replication | `bool` | `false` | no |
+| <a name="input_replication_object_lock_days"></a> [replication\_object\_lock\_days](#input\_replication\_object\_lock\_days) | The number of days that you want to specify for the replication bucket default retention period | `number` | `null` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create S3 replication bucket | `string` | `"eu-west-2"` | no |
 | <a name="input_replication_role_arn"></a> [replication\_role\_arn](#input\_replication\_role\_arn) | Role ARN to access S3 and replicate objects | `string` | `""` | no |
 | <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | S3 server-side encryption algorithm. Defaults to aws:kms. Use AES256 only for compatibility scenarios where SSE-KMS is not supported. | `string` | `"aws:kms"` | no |

--- a/replication.tf
+++ b/replication.tf
@@ -97,6 +97,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "replication" {
   }
 }
 
+resource "aws_s3_bucket_object_lock_configuration" "replication" {
+  count    = var.replication_enabled && var.replication_object_lock_days != null ? 1 : 0
+  provider = aws.bucket-replication
+  bucket   = aws_s3_bucket.replication[0].id
+
+  rule {
+    default_retention {
+      mode = "COMPLIANCE"
+      days = var.replication_object_lock_days
+    }
+  }
+}
+
 # Block public access policies to the replication bucket
 resource "aws_s3_bucket_public_access_block" "replication" {
   count = var.replication_enabled ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -247,3 +247,9 @@ variable "object_lock_days" {
   description = "The number of days that you want to specify for the default retention period"
   default     = null
 }
+
+variable "replication_object_lock_days" {
+  type        = number
+  description = "The number of days that you want to specify for the replication bucket default retention period"
+  default     = null
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

ministryofjustice/modernisation-platform#13105.

This adds support for enabling S3 Object Lock default retention on replication buckets created by this module. 

## How does this PR fix the problem?

Adds a new optional `replication_object_lock_days` input.

When `replication_enabled = true` and `replication_object_lock_days` is set, the module now creates an `aws_s3_bucket_object_lock_configuration` resource for the replication bucket using the `aws.bucket-replication` provider.

The default remains `null`, so existing module consumers are unaffected unless they explicitly opt in.
