### PR TITLE
Enables S3 replication metrics

### DIFF
--- a/replication.tf
+++ b/replication.tf
@@ -294,6 +294,11 @@ resource "aws_s3_bucket_replication_configuration" "default" {
     destination {
       bucket        = aws_s3_bucket.replication[0].arn
       storage_class = "STANDARD"
+
+      metrics {
+        status = "Enabled"
+      }
+
       dynamic "encryption_configuration" {
         for_each = var.sse_algorithm == "aws:kms" ? [1] : []
 


### PR DESCRIPTION
Tracked here: https://github.com/ministryofjustice/modernisation-platform/issues/13496

Enabling replication metrics provides the signals required to create CloudWatch alarms and object-level failure notifications for replicated bucket.
This enables monitoring of:

- Failed replication operations
- Pending replication operations
- Bytes pending replication
- Replication latency
