### PR TITLE
Make S3 replication metrics configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ No modules.
 | <a name="input_ownership_controls"></a> [ownership\_controls](#input\_ownership\_controls) | Bucket Ownership Controls - for use WITH acl var above options are 'BucketOwnerPreferred' or 'ObjectWriter'. To disable ACLs and use new AWS recommended controls set this to 'BucketOwnerEnforced' and which will disabled ACLs and ignore var.acl | `string` | `"ObjectWriter"` | no |
 | <a name="input_replication_bucket"></a> [replication\_bucket](#input\_replication\_bucket) | Name of bucket used for replication - if not specified then * will be used in the policy | `string` | `""` | no |
 | <a name="input_replication_enabled"></a> [replication\_enabled](#input\_replication\_enabled) | Activate S3 bucket replication | `bool` | `false` | no |
+| <a name="input_replication_metrics_enabled"></a> [replication\_metrics\_enabled](#input\_replication\_metrics\_enabled) | Enable CloudWatch metrics and events for S3 replication | `bool` | `false` | no |
 | <a name="input_replication_object_lock_days"></a> [replication\_object\_lock\_days](#input\_replication\_object\_lock\_days) | The number of days that you want to specify for the replication bucket default retention period | `number` | `null` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | Region to create S3 replication bucket | `string` | `"eu-west-2"` | no |
 | <a name="input_replication_role_arn"></a> [replication\_role\_arn](#input\_replication\_role\_arn) | Role ARN to access S3 and replicate objects | `string` | `""` | no |

--- a/replication.tf
+++ b/replication.tf
@@ -295,8 +295,12 @@ resource "aws_s3_bucket_replication_configuration" "default" {
       bucket        = aws_s3_bucket.replication[0].arn
       storage_class = "STANDARD"
 
-      metrics {
-        status = "Enabled"
+      dynamic "metrics" {
+        for_each = var.replication_metrics_enabled ? [1] : []
+
+        content {
+          status = "Enabled"
+        }
       }
 
       dynamic "encryption_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "replication_enabled" {
   default     = false
 }
 
+variable "replication_metrics_enabled" {
+  type        = bool
+  description = "Enable CloudWatch metrics and events for S3 replication"
+  default     = false
+}
+
 variable "replication_region" {
   type        = string
   description = "Region to create S3 replication bucket"


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform/issues/13496
Adds an opt-in setting for enabling Amazon S3 replication metrics. 
Keeping the change backward-compatible as this is a shared module. Existing consumers can upgrade without unexpectedly changing their replication configuration or incurring additional CloudWatch costs.